### PR TITLE
Remove CNAME to avoid publishing this as geogig.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-geogig.org
+


### PR DESCRIPTION
Right now we have both boundlessgeo/geogig and locationtech/geogig configured for geogig.org redirection!

This pull request is the first step, the second step is updating redirect with DNS provider.